### PR TITLE
Revert "WSFM: Optimize writing large areas of 0xFF bytes."

### DIFF
--- a/src/cartridge/ws_cartridge.cpp
+++ b/src/cartridge/ws_cartridge.cpp
@@ -453,7 +453,7 @@ void ws_cartridge::restore_cartridge_game_data(std::istream& fin, int slot, task
   // Begin writing data block-by-block
   try
   {
-    // Open connection to WS chip
+    // Open connection to NGP chip
     m_linkmasta->open();
     
     while (bytes_written < bytes_total && (controller == nullptr || !controller->is_task_cancelled()))

--- a/src/cartridge/ws_rom_chip.cpp
+++ b/src/cartridge/ws_rom_chip.cpp
@@ -147,18 +147,12 @@ protect_t ws_rom_chip::get_block_protection(address_t sector_address)
 
 void ws_rom_chip::program_word(address_t address, word_t data)
 {
-  // Writing a 0xFF value to NOR flash is equivalent to a no-operation.
-  if (data == 0xFF)
-  {
-	return;
-  }
-  
   if (is_erasing())
   {
     // We can only reset when we're not erasing
     throw std::runtime_error("Chip still erasing");
   }
-
+  
   // Reset if in autoselect mode
   if (current_mode() != BYPASS && current_mode() != READ)
   {

--- a/src/linkmasta/ws_linkmasta_device.cpp
+++ b/src/linkmasta/ws_linkmasta_device.cpp
@@ -379,22 +379,6 @@ unsigned int ws_linkmasta_device::read_bytes(chip_index chip, address_t start_ad
   return offset;
 }
 
-static bool program_operation_is_noop(chip_index chip, const data_t *buffer, unsigned int num_bytes)
-{
-  if (chip == target_enum::TARGET_ROM)
-  {
-    for (unsigned int i = 0; i < num_bytes; i++)
-    {
-      if (((const uint8_t *) buffer)[i] != 0xFF)
-      {
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
 unsigned int ws_linkmasta_device::program_bytes(chip_index chip, address_t start_address, const data_t *buffer, unsigned int num_bytes, bool bypass_mode, task_controller* controller)
 {
   (void) bypass_mode;
@@ -436,50 +420,7 @@ unsigned int ws_linkmasta_device::program_bytes(chip_index chip, address_t start
     {
       num_packets = std::numeric_limits<uint8_t>::max();
     }
-
-    if (chip == target_enum::TARGET_ROM)
-    {
-      // Optimization: If the next packet contains only 0xFF bytes, a write to a
-      // NOR-based flash chip will be equivalent to a no-operation. Skip.
-      if (program_operation_is_noop(chip, &buffer[offset], WS_LINKMASTA_USB_RXTX_SIZE))
-      {
-        // Update offset and inform controller of progress
-        offset += WS_LINKMASTA_USB_RXTX_SIZE;
-        if (controller != nullptr)
-        {
-          controller->on_task_update(task_status::RUNNING, WS_LINKMASTA_USB_RXTX_SIZE);
-        }
-        continue;
-      }
-
-      // Optimization: Do the same to the right-hand side, from a certain minimum
-      // burst size.
-      uint8_t first_skippable_num_packets = 0;
-      uint8_t skippable_num_packets_count = 0;
-      for (uint8_t i = 4; i < num_packets; i++)
-      {
-        if (program_operation_is_noop(chip, &buffer[offset + (WS_LINKMASTA_USB_RXTX_SIZE * i)],
-          WS_LINKMASTA_USB_RXTX_SIZE))
-        {
-          if (first_skippable_num_packets == 0)
-          {
-            first_skippable_num_packets = i;
-            skippable_num_packets_count = 0;
-          }
-          skippable_num_packets_count++;
-          if (skippable_num_packets_count >= 4)
-          {
-            num_packets = first_skippable_num_packets;
-            break;
-          }
-        }
-        else
-        {
-          first_skippable_num_packets = 0;
-        }
-      }
-    }
-
+    
     // Treat writes to flash and sram differently
     switch (chip)
     {


### PR DESCRIPTION
Reverts doccaz/Flash-Masta-Desktop#1, could be causing issues with writing entire cartridge.